### PR TITLE
Updated GH actions configuration

### DIFF
--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -3,7 +3,7 @@ name: Publish Docs
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -7,7 +7,7 @@ on:
   release:
     types: [created]
     branches:
-      - master
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
Changed branch name to ``main`` in GitHub actions for publishing documentation and releases.